### PR TITLE
allow replacing import path prefixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 
 go:
-    - 1.4
+    - "1.10"
     - tip

--- a/README.md
+++ b/README.md
@@ -9,23 +9,22 @@ Tool to rewrite import paths and [package import comments](https://golang.org/s/
 go get github.com/dmitris/prewrite
 
 # Usage
-prewrite -p prefix [-r] [-v] [path ...]
+prewrite -p prefix [-r] [-v] [path]
 
 # Command-line arguments
-* -p prefix -- prefix to add to imports and package import comments or remove (with -r) - required
-* -r        -- remove the given prefix from import statements and package import comments
+* -from &lt;oldprefix&gt; -to &lt;newprefix&gt; -- rewrite import paths replacing oldprefix with newprefix
 * -v        -- verbosely print the names of the changed files
 
-If not provided, the path defaults to the current directory (will recursively traverse). Multiple targets can be given.
+Example: `prewrite -from go.oldcompany.com -new go.newcompany.com`.
 
-The last target parameter can be either a single file or a directory (such as a root of a source tree).
+If not provided, the path defaults to the current directory (will recursively traverse).  Either a single file or a directory (such as a root of a source tree) can be given.
 
 # Examples
 
-Add a prefix to all imports (except the standard library) and package comment paths under the current directory:  
-prewrite -p go.corp.company.com/x -v
+Change the prefix in all the imports (except the standard library) and package comment paths under the current directory:  
+prewrite -from go.stealthy.com -to go.nextunicorn.com
 
-Remove a prefix from all imports and package comment paths under the current directory:  
-prewrite -p go.corp.company.com/x -r -v
+Remove a prefix from all imports and package comment paths under the directory /tmp/foobar :  
+prewrite -from go.stealthy.company.com/go.theunicorn.com -to go.nextunicorn.com /tmp/foobar
 
 

--- a/astmod/testdata/ext1.go
+++ b/astmod/testdata/ext1.go
@@ -1,9 +1,9 @@
-// package doc comment for github.com/foo/bar
-package bar // import "github.com/foo/bar"
+// package doc comment for go.corp.company.com/abc/xyz
+package bar // import "go.corp.company.com/abc/xyz"
 
-import _ "github.com/abc/xyz"
+import _ "go.corp.company.com/abc/xyz"
 
 func Bar() {
 	// unrelated comment in func
-	println("Hello, World! (from github.com/foo/bar)")
+	println("Hello, World! (from go.corp.company.com/abc/xyz)")
 }

--- a/astmod/testdata/helloworld.go
+++ b/astmod/testdata/helloworld.go
@@ -1,6 +1,10 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+
+	_ "go.newcompany.com/abc/xyz"
+)
 
 func main() {
 	fmt.Println("Hello, world!")

--- a/astmod/testdata/int1.go
+++ b/astmod/testdata/int1.go
@@ -1,9 +1,9 @@
-// package doc comment for github.com/foo/bar
-package bar // import "go.corp.example.com/x/github.com/foo/bar"
+// package doc comment for go.corp.company.com/abc/xyz
+package bar // import "go.newcompany.com/abc/xyz"
 
-import _ "go.corp.example.com/x/github.com/abc/xyz"
+import _ "go.newcompany.com/abc/xyz"
 
 func Bar() {
 	// unrelated comment in func
-	println("Hello, World! (from github.com/foo/bar)")
+	println("Hello, World! (from go.corp.company.com/abc/xyz)")
 }


### PR DESCRIPTION
PR allows to replace import path prefixes with `from` and `to` parameters (instead of just adding or removing to the prefix as previously).   This could come useful when migrating codebases - for example from one domain to another.  The adding to the import path or truncating the prefix is still possible - for example, prefix truncation with `-from oldpart.keep.this.company.name -to keep.this.company.name`.