### PR TITLE
rework prewrite, add plist program

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,42 @@ prewrite
 
 [![Build Status](https://travis-ci.org/dmitris/prewrite.svg?branch=master)](https://travis-ci.org/dmitris/prewrite)
 
-Tool to rewrite import paths and [package import comments](https://golang.org/s/go14customimport) for vendoring by adding or removing a given path prefix.  The files are rewritten in-place with no backup (expectation is that version control is used), the output is gofmt'ed.
+The repository contains `plist` and `prewrite` tools under `cmd/` subdirectory.
 
 # Install
-go get github.com/dmitris/prewrite
+go get github.com/dmitris/prewrite/...
 
-# Usage
+# prewrite
+## Usage:
+```
 prewrite -p prefix [-r] [-v] [path ...]
+```
 
-# Command-line arguments
-* -p prefix -- prefix to add to imports and package import comments or remove (with -r) - required
-* -r        -- remove the given prefix from import statements and package import comments
+## Command-line arguments
+* -from -- the old prefix to change in the imports statements (required)
+* - to -- new prefix to add instead of the old one
 * -v        -- verbosely print the names of the changed files
 
-If not provided, the path defaults to the current directory (will recursively traverse). Multiple targets can be given.
+If not provided, the path defaults to the current directory (will recursively traverse).
 
 The last target parameter can be either a single file or a directory (such as a root of a source tree).
 
-# Examples
+## Examples
 
-Add a prefix to all imports (except the standard library) and package comment paths under the current directory:  
-prewrite -p go.corp.company.com/x -v
+Change the prefix for all imports (except the standard library) under the current directory
+from "github.com/*" to "gitlab.com/*"
+`prewrite -from github.com -to gitlab.com`
 
-Remove a prefix from all imports and package comment paths under the current directory:  
-prewrite -p go.corp.company.com/x -r -v
-
+# plist
+## Usage
+```
+usage: plist -prefix [path ...]
+  -all
+    	list all imports (-p is ignored)
+  -o string
+    	output file to write the imports listing
+  -p string
+    	import prefix to match
+  -v	verbose
+```
 

--- a/astmod/README.md
+++ b/astmod/README.md
@@ -4,5 +4,6 @@ astmod
 [![Build Status](https://travis-ci.org/dmitris/prewrite.svg?branch=master)](https://travis-ci.org/dmitris/prewrite)
 [![GoDoc](https://godoc.org/github.com/dmitris/prewrite/astmod?status.svg)](https://godoc.org/github.com/dmitris/prewrite/astmod)
 
-GO AST manipulation library to rewrite import statement and package import comments in the AST (in-place).
+Go AST manipulation library to rewrite import statement in the AST (in-place).
+Also allows listing the imports matching the given prefix.
 

--- a/astmod/doc.go
+++ b/astmod/doc.go
@@ -1,0 +1,4 @@
+// Astmod is a Go AST manipulation library to rewrite import statement
+// in the AST (in-place).
+// It also allows listing the imports matching the given prefix.
+package astmod

--- a/astmod/list.go
+++ b/astmod/list.go
@@ -1,0 +1,66 @@
+package astmod
+
+import (
+	"go/parser"
+	"go/token"
+	"log"
+	"sort"
+	"strings"
+)
+
+// ImportSpec is a slimmed-down version of https://golang.org/pkg/go/ast/#ImportSpec.
+type ImportSpec struct {
+	Name, Path string
+}
+
+// String prints the import with the name field prepended (if not empty).
+func (i *ImportSpec) String() string {
+	if i == nil {
+		return ""
+	}
+	if i.Name != "" {
+		return i.Name + " " + i.Path
+	}
+	return i.Path
+}
+
+// ListImports returns a set of ImportSpec objects with imports
+// matching the given prefix.
+func ListImports(fname string, src interface{}, prefix string) ([]*ImportSpec, error) {
+	// Create the AST by parsing src.
+	fset := token.NewFileSet() // positions are relative to fset
+	f, err := parser.ParseFile(fset, fname, src, parser.ImportsOnly)
+	if err != nil {
+		log.Printf("Error parsing file %s, source: [%s], error: %s", fname, src, err)
+		return nil, err
+	}
+	var ret []*ImportSpec
+	for _, imp := range f.Imports {
+		path := strings.Replace(imp.Path.Value, `"`, "", -1)
+		if !strings.HasPrefix(path, prefix) {
+			continue
+		}
+		spec := &ImportSpec{}
+		if imp.Name != nil {
+			spec.Name = imp.Name.Name
+		}
+		spec.Path = path
+		ret = append(ret, spec)
+	}
+	return ret, nil
+}
+
+// ListImportPaths returns a slice of strings for the unique imports paths
+// matching the given prefix.
+func ListImportPaths(fname string, src interface{}, prefix string) ([]string, error) {
+	imps, err := ListImports(fname, src, prefix)
+	if err != nil {
+		return nil, err
+	}
+	var ret []string
+	for _, imp := range imps {
+		ret = append(ret, imp.Path)
+	}
+	sort.Strings(ret)
+	return ret, nil
+}

--- a/astmod/list_test.go
+++ b/astmod/list_test.go
@@ -1,0 +1,52 @@
+package astmod
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestListImports(t *testing.T) {
+	// tests table
+	tests := []struct {
+		in      string
+		prefix  string
+		imports []string
+		label   string
+	}{
+		{in: "ext1.go",
+			prefix:  "github.com",
+			imports: []string{"github.com/abc/xyz"},
+			label:   "ext1 correct prefix",
+		},
+		{in: "ext1.go",
+			prefix:  "gitlab.com",
+			imports: nil,
+			label:   "ext1 non-existent prefix",
+		},
+		{in: "helloworld.go",
+			prefix:  "",
+			imports: []string{"fmt"},
+			label:   "helloworld",
+		},
+		{in: "int1.go",
+			prefix:  "go.corp.example.com",
+			imports: []string{"go.corp.example.com/abc/xyz"},
+			label:   "int1",
+		},
+	}
+	for _, tt := range tests {
+		fname := filepath.Join("testdata", tt.in)
+		imports, err := ListImports(fname, nil, tt.prefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var importPaths []string
+		for _, imp := range imports {
+			importPaths = append(importPaths, imp.Path)
+		}
+		if !reflect.DeepEqual(importPaths, tt.imports) {
+			t.Errorf("%s: bad result %v, want %v", tt.label, importPaths, tt.imports)
+		}
+	}
+}

--- a/astmod/rewrite.go
+++ b/astmod/rewrite.go
@@ -17,12 +17,12 @@ import (
 	"strings"
 )
 
-// Rewrite modifies the AST to rewrite import statements and package import comments.
+// Rewrite modifies the AST to rewrite import statements.
 // src should be compatible with go/parser/#ParseFile:
 // (The type of the argument for the src parameter must be string, []byte, or io.Reader.)
 //
 // return of nil, nil (no result, no error) means no changes are needed
-func Rewrite(fname string, src interface{}, prefix string, remove bool) (buf *bytes.Buffer, err error) {
+func Rewrite(fname string, src interface{}, fromPrefix, toPrefix string) (buf *bytes.Buffer, err error) {
 	// Create the AST by parsing src.
 	fset := token.NewFileSet() // positions are relative to fset
 	f, err := parser.ParseFile(fset, fname, src, parser.ParseComments)
@@ -30,22 +30,13 @@ func Rewrite(fname string, src interface{}, prefix string, remove bool) (buf *by
 		log.Printf("Error parsing file %s, source: [%s], error: %s", fname, src, err)
 		return nil, err
 	}
-	// normalize the prefix ending with a trailing slash
-	if prefix[len(prefix)-1] != '/' {
-		prefix += "/"
-	}
 
-	changed, err := RewriteImports(f, prefix, remove)
+	changed, err := RewriteImports(f, fromPrefix, toPrefix)
 	if err != nil {
 		log.Printf("Error rewriting imports in the AST: file %s - %s", fname, err)
 		return nil, err
 	}
-	changed2, err := RewriteImportComments(f, fset, prefix, remove)
-	if err != nil {
-		log.Printf("Error rewriting import comments in the AST: file %s - %s", fname, err)
-		return nil, err
-	}
-	if !changed && !changed2 {
+	if !changed {
 		return nil, nil
 	}
 	buf = &bytes.Buffer{}
@@ -56,7 +47,7 @@ func Rewrite(fname string, src interface{}, prefix string, remove bool) (buf *by
 // RewriteImports rewrites imports in the passed AST (in-place).
 // It returns bool changed set to true if any changes were made
 // and non-nil err on error
-func RewriteImports(f *ast.File, prefix string, remove bool) (changed bool, err error) {
+func RewriteImports(f *ast.File, fromPrefix, toPrefix string) (changed bool, err error) {
 	for _, impNode := range f.Imports {
 		imp, err := strconv.Unquote(impNode.Path.Value)
 		if err != nil {
@@ -67,70 +58,10 @@ func RewriteImports(f *ast.File, prefix string, remove bool) (changed bool, err 
 		if !strings.Contains(imp, ".") || strings.HasPrefix(imp, ".") {
 			continue
 		}
-		if remove {
-			if strings.HasPrefix(imp, prefix) {
-				changed = true
-				impNode.Path.Value = strconv.Quote(imp[len(prefix):])
-			}
-		} else {
-			// if import does not start with the prefix already, add it
-			if !strings.HasPrefix(imp, prefix) {
-				changed = true
-				impNode.Path.Value = strconv.Quote(prefix + imp)
-			}
+		if strings.HasPrefix(imp, fromPrefix) {
+			changed = true
+			impNode.Path.Value = strconv.Quote(toPrefix + imp[len(fromPrefix):])
 		}
 	}
 	return
-}
-
-// RewriteImportComments rewrites package import comments (https://golang.org/s/go14customimport)
-func RewriteImportComments(f *ast.File, fset *token.FileSet, prefix string, remove bool) (changed bool, err error) {
-	pkgpos := fset.Position(f.Package)
-	// Print the AST.
-	// ast.Print(fset, f)
-	newcommentgroups := make([]*ast.CommentGroup, 0)
-	for _, c := range f.Comments {
-		commentpos := fset.Position(c.Pos())
-		// keep the comment if we are not on the "package <X>" line
-		// or the comment after the package statement does not look like import comment
-		if commentpos.Line != pkgpos.Line ||
-			!strings.HasPrefix(c.Text(), `import "`) {
-			newcommentgroups = append(newcommentgroups, c)
-			continue
-		}
-		parts := strings.Split(strings.Trim(c.Text(), "\n\r\t "), " ")
-		oldimp, err := strconv.Unquote(parts[1])
-		if err != nil {
-			log.Fatalf("Error unquoting import value [%v] - %s\n", parts[1], err)
-		}
-
-		if remove {
-			// the prefix is not there = nothing to remove, keep the comment
-			if !strings.HasPrefix(oldimp, prefix) {
-				newcommentgroups = append(newcommentgroups, c)
-				continue
-			}
-		} else {
-			// the prefix is already in the import path, keep the comment
-			if strings.HasPrefix(oldimp, prefix) {
-				newcommentgroups = append(newcommentgroups, c)
-				continue
-			}
-		}
-		newimp := ""
-		if remove {
-			newimp = oldimp[len(prefix):]
-		} else {
-			newimp = prefix + oldimp
-		}
-		changed = true
-		c2 := ast.Comment{Slash: c.Pos(), Text: `// import ` + strconv.Quote(newimp)}
-		cg := ast.CommentGroup{List: []*ast.Comment{&c2}}
-		newcommentgroups = append(newcommentgroups, &cg)
-	}
-	// change the AST only if there are pending mods
-	if changed {
-		f.Comments = newcommentgroups
-	}
-	return changed, nil
 }

--- a/astmod/testdata/ext1.go.golden
+++ b/astmod/testdata/ext1.go.golden
@@ -1,7 +1,7 @@
 // package doc comment for github.com/foo/bar
 package bar
 
-import _ "github.com/abc/xyz"
+import _ "gitlab.com/abc/xyz"
 
 func Bar() {
 	// unrelated comment in func

--- a/astmod/testdata/helloworld.go.golden
+++ b/astmod/testdata/helloworld.go.golden
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}

--- a/astmod/testdata/int1.go
+++ b/astmod/testdata/int1.go
@@ -1,7 +1,7 @@
 // package doc comment for github.com/foo/bar
-package bar // import "go.corp.example.com/x/github.com/foo/bar"
+package bar
 
-import _ "go.corp.example.com/x/github.com/abc/xyz"
+import _ "go.corp.example.com/abc/xyz"
 
 func Bar() {
 	// unrelated comment in func

--- a/astmod/testdata/int1.go.golden
+++ b/astmod/testdata/int1.go.golden
@@ -1,7 +1,7 @@
 // package doc comment for github.com/foo/bar
 package bar
 
-import _ "github.com/abc/xyz"
+import _ "go.brandnewcorp.com/abc/xyz"
 
 func Bar() {
 	// unrelated comment in func

--- a/cmd/plist/plist.go
+++ b/cmd/plist/plist.go
@@ -1,0 +1,125 @@
+// Copyright Verizon Meida, Inc. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+//
+// Author: Dmitry Savintsev <dsavints@verizonmedia.com>
+
+// Plist list imports matching the given prefix.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/dmitris/prewrite/astmod"
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage: plist -prefix [path ...]\n")
+	flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func main() {
+	allOpt := flag.Bool("all", false, "list all imports (-p is ignored)")
+	prefixOpt := flag.String("p", "", "import prefix to match")
+	outputOpt := flag.String("o", "", "output file to write the imports listing")
+	verboseOpt := flag.Bool("v", false, "verbose")
+	flag.Usage = usage
+	flag.Parse()
+	prefix := *prefixOpt
+	verbose := *verboseOpt
+
+	var root string
+	var err error
+	if len(flag.Args()) < 1 {
+		root, err = os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		root = flag.Arg(0)
+	}
+
+	if prefix == "" && !*allOpt {
+		log.Fatalf("invalid flags: no prefix given with -p and -all not set")
+	}
+	if *allOpt {
+		prefix = ""
+	}
+
+	var (
+		impts []string
+		mu    sync.Mutex
+		w     io.Writer
+	)
+
+	if *outputOpt == "" {
+		w = os.Stdout
+	} else {
+		f, err := os.Open(*outputOpt)
+		if err != nil {
+			log.Fatalf("unable to open output file %s: %v", *outputOpt, err)
+		}
+		w = f
+		defer f.Close()
+	}
+	lister := makeLister(w, prefix, &impts, &mu, verbose)
+	_, err = os.Stat(root)
+	if err != nil && os.IsNotExist(err) {
+		log.Fatalf("Error - the traversal root %s does not exist, please double-check\n", root)
+	}
+	if err := filepath.Walk(root, lister); err != nil {
+		log.Fatalf("Error listing imports %s: %s\n", flag.Arg(0), err)
+	}
+	uniq := map[string]bool{}
+	var allImports []string
+	for _, impt := range impts {
+		if _, ok := uniq[impt]; !ok {
+			uniq[impt] = true
+			allImports = append(allImports, impt)
+		}
+	}
+	sort.Strings(allImports)
+	for _, impt := range allImports {
+		fmt.Fprintln(w, impt)
+	}
+	return
+}
+
+// makeLister returns an imports listing function with parameters bound with a closure
+func makeLister(w io.Writer,
+	prefix string,
+	imptsOut *[]string,
+	mu *sync.Mutex,
+	verbose bool) filepath.WalkFunc {
+	return func(path string, f os.FileInfo, err error) error {
+		if f.IsDir() || !strings.HasSuffix(f.Name(), ".go") {
+			return nil
+		}
+		src, err := ioutil.ReadFile(path)
+		if err != nil {
+			log.Fatalf("Fatal error reading file %s\n", path)
+		}
+		impts, err := astmod.ListImportPaths(path, src, prefix)
+		if err != nil {
+			log.Fatalf("Fatal error rewriting AST, file %s - error: %s\n", path, err)
+		}
+
+		mu.Lock()
+		for _, imp := range impts {
+			*imptsOut = append(*imptsOut, imp)
+		}
+		mu.Unlock()
+
+		return nil
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dmitris/prewrite
+
+go 1.14


### PR DESCRIPTION
PR modified `prewrite` to take`from` and `to` prefix parameters and modify all the imports with an equivalent of `s/^<from>/^<to>/g`.  Also add a `plist` program that takes `-p` prefix parameter and lists all the imports matching it as a unique sorted list.

This could be used when doing a large-scale migrations from one package base to another such as `github.com/foo/bar` to `gitlab.com/newfoo/newbar` etc.